### PR TITLE
Better documentation on supported ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [3.2, 3.3]
+        ruby: [truffleruby, jruby, 3.0, 3.1, 3.2, 3.3]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     ast (2.4.2)
     diff-lcs (1.5.1)
     json (2.7.2)
+    json (2.7.2-java)
     language_server-protocol (3.17.0.3)
     opentelemetry-api (1.2.5)
     opentelemetry-common (0.20.1)
@@ -30,6 +31,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.7.3)
+    racc (1.7.3-java)
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.1)
@@ -82,6 +84,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  universal-java-11
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -53,3 +53,8 @@ Several conditions can be added to the matcher:
 * `without_exception` - Will match only the spans that do not have the specified exception event.
 
 The `*_event` condition can be called multiple times with different events.
+
+## Compatibility
+
+RSpec Otel ensures compatibility with the currently supported versions of the
+[Ruby Language](https://www.ruby-lang.org/en/downloads/branches/).


### PR DESCRIPTION
Also, add every version otel-go tests to the spec matrix.