### PR TITLE
Add assertions for root and child spans

### DIFF
--- a/lib/rspec_otel/matchers/emit_span.rb
+++ b/lib/rspec_otel/matchers/emit_span.rb
@@ -2,7 +2,7 @@
 
 module RspecOtel
   module Matchers
-    class EmitSpan
+    class EmitSpan # rubocop:disable Metrics/ClassLength
       attr_reader :name
 
       def initialize(name = nil)
@@ -24,6 +24,22 @@ module RspecOtel
         end
 
         false
+      end
+
+      def as_child
+        @filters << lambda do |span|
+          span.parent_span_id && span.parent_span_id != OpenTelemetry::Trace::INVALID_SPAN_ID
+        end
+
+        self
+      end
+
+      def as_root
+        @filters << lambda do |span|
+          span.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID
+        end
+
+        self
       end
 
       def with_attributes(attributes)


### PR DESCRIPTION
Thanks for making the gem!

I was wondering what you thought of the following idea, to be able to detect root spans. 

This is something I have written some matchers for in the org I am part of as it is helpful as a library for framework author to make assertions that certain paths should create new traces.

However, I am unsure about the API for rspec-otel.

Some possibilities I thought of:

```ruby 
expect{ }.to emit_span('child', root: false|true)
expect{ }.to emit_root_span('child')
expect{ }.to emit_span('child').as_root
```

Please see attached an implementation for the first option. However, I think I prefer `expect{ }.to emit_root_span('child')` most.

Let me know what you think.