### PR TITLE
Introduce RSPEC_OTEL_DEBUG for printing captured spans during test runs

### DIFF
--- a/lib/rspec_otel/matchers/emit_span.rb
+++ b/lib/rspec_otel/matchers/emit_span.rb
@@ -20,6 +20,8 @@ module RspecOtel
         end
 
         (RspecOtel.exporter.finished_spans - before_spans).each do |span|
+          puts span if ENV['RSPEC_OTEL_DEBUG']
+
           return true if @filters.all? { |f| f.call(span) }
         end
 


### PR DESCRIPTION
In using this gem to write tests I found that sometimes I know the telemetry being exported is good and I just want to see what it is so that I can quickly write tests for it's name, attributes etc.

In this case I'd like the gem to be able to show me what spans were exported, either through updating the failure message to show the spans that didn't match my specified criteria, or in this simple case I just print all captured spans.

What do you think about this idea, but not necessarily this method?