### PR TITLE
Extend with_attributes/without_attributes to match on keys only or types of values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       opentelemetry-api (~> 1.0)
       opentelemetry-sdk (~> 1.0)
       rspec-core (~> 3.0)
+      rspec-expectations (~> 3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/rspec_otel/matchers/emit_span.rb
+++ b/lib/rspec_otel/matchers/emit_span.rb
@@ -42,17 +42,17 @@ module RspecOtel
         self
       end
 
-      def with_attributes(attributes)
+      def with_attributes(*attributes)
         @filters << lambda do |span|
-          attributes_match?(span.attributes, attributes)
+          RSpec::Matchers::BuiltIn::Include.new(*attributes).matches?(span.attributes)
         end
 
         self
       end
 
-      def without_attributes(attributes)
+      def without_attributes(*attributes)
         @filters << lambda do |span|
-          !attributes_match?(span.attributes, attributes)
+          !RSpec::Matchers::BuiltIn::Include.new(*attributes).matches?(span.attributes)
         end
 
         self

--- a/rspec-otel.gemspec
+++ b/rspec-otel.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_dependency 'rspec-core', '~> 3.0'
+  spec.add_dependency 'rspec-expectations', '~> 3.0'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/rspec_otel/matchers/emit_span_spec.rb
+++ b/spec/rspec_otel/matchers/emit_span_spec.rb
@@ -63,6 +63,28 @@ describe RspecOtel::Matchers::EmitSpan do
       end.to emit_span('test').with_attributes({ 'hello' => 'world' })
     end
 
+    it 'matches a span by attribute keys' do
+      expect do
+        span = OpenTelemetry.tracer_provider.tracer('rspec-otel')
+                            .start_span('test', attributes: {
+                                          'hello' => 'world',
+                                          'holla' => 'mundo'
+                                        })
+        span.finish
+      end.to emit_span('test').with_attributes('hello', 'holla')
+    end
+
+    it 'matches a span by attribute value types' do
+      expect do
+        span = OpenTelemetry.tracer_provider.tracer('rspec-otel')
+                            .start_span('test', attributes: {
+                                          'hello' => 'world',
+                                          'holla' => 1
+                                        })
+        span.finish
+      end.to emit_span('test').with_attributes({ 'hello' => String, 'holla' => Integer })
+    end
+
     it 'does not match a span with wrong attributes' do
       expect do
         span = OpenTelemetry.tracer_provider.tracer('rspec-otel')


### PR DESCRIPTION
In my use of this gem I sometimes don't care about the specific value of the attributes in my span, or might not even know the value of them ahead of time to set up expectations.

Having the ability to expect only that attributes exist, and not their exact value would be useful.

To accomplish this tried to see if the built in matchers for Arrays and Hashes in rspec-expectations could be used. This feels a bit dirty but works surprisingly nice and I wonder what your thoughts are on this in general?